### PR TITLE
update render.go

### DIFF
--- a/godocdown/render.go
+++ b/godocdown/render.go
@@ -48,7 +48,7 @@ func renderTypeSectionTo(writer io.Writer, list []*doc.Type) {
 }
 
 func renderHeaderTo(writer io.Writer, document *_document) {
-	fmt.Fprintf(writer, "# %s\n--\n", document.Name)
+	fmt.Fprintf(writer, "# %s\n---\n", document.Name)
 
 	if !document.IsCommand {
 		// Import
@@ -83,6 +83,6 @@ func renderUsageTo(writer io.Writer, document *_document) {
 
 func renderSignatureTo(writer io.Writer) {
 	if RenderStyle.IncludeSignature {
-		fmt.Fprintf(writer, "\n\n--\n**godocdown** http://github.com/robertkrimen/godocdown\n")
+		fmt.Fprintf(writer, "\n\n---\n**godocdown** http://github.com/robertkrimen/godocdown\n")
 	}
 }


### PR DESCRIPTION
Fix: Horizontal line for plain markup; horizontal line in plain markup requires 3 dashes, tested on Gitlab, MarkDownPad v2